### PR TITLE
fix(chart): use secret for db password in wait-for-db init container

### DIFF
--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -81,7 +81,15 @@ spec:
             - name: POSTGRES_USER
               value: {{ .Values.marquez.db.user | quote }}
             - name: PGPASSWORD
-              value: {{ .Values.marquez.db.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.marquez.existingSecretName }}
+                  name: {{ .Values.marquez.existingSecretName }}
+                  key: marquez-db-password
+                  {{- else }}
+                  name: {{ include "ilum-marquez.fullname" . }}
+                  key: marquez-db-password
+                  {{- end }}
             - name: POSTGRES_DB
               value: {{ .Values.marquez.db.name | quote }}
         {{- end }}


### PR DESCRIPTION
The wait-for-db init container was using a hardcoded password from values.yaml instead of referencing the secret. This commit updates the init container to use valueFrom.secretKeyRef for PGPASSWORD, supporting both existingSecretName and the default secret, consistent with the main container.
