### PR TITLE
Fix duplicate dataset fields explosion on null types #3083

### DIFF
--- a/api/src/main/java/marquez/db/DatasetFieldDao.java
+++ b/api/src/main/java/marquez/db/DatasetFieldDao.java
@@ -262,7 +262,7 @@ public interface DatasetFieldDao extends BaseDao {
           + "description"
           + ") VALUES ("
           + ":uuid, "
-          + ":type, "
+          + "COALESCE(:type, 'UNKNOWN'), "
           + ":now, "
           + ":now, "
           + ":datasetUuid, "

--- a/api/src/test/java/marquez/MarquezAppIntegrationTest.java
+++ b/api/src/test/java/marquez/MarquezAppIntegrationTest.java
@@ -200,7 +200,11 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
             .build();
     final Dataset dataset =
         client.createDataset(NAMESPACE_NAME, datasetName.getValue(), dbTableMeta);
-    assertThat(dataset.getFields()).containsExactly(field0, field1);
+    
+    // We expect the type to be UNKNOWN if the input type is null to avoid duplicate rows
+    // in the dataset_fields table.
+    final Field expectedField1 = Field.builder().name("field1").type("UNKNOWN").build();
+    assertThat(dataset.getFields()).containsExactly(field0, expectedField1);
   }
 
   @Test

--- a/api/src/test/java/marquez/db/DatasetFieldDaoTest.java
+++ b/api/src/test/java/marquez/db/DatasetFieldDaoTest.java
@@ -1,0 +1,103 @@
+package marquez.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import marquez.api.JdbiUtils;
+import marquez.common.models.DatasetType;
+import marquez.db.models.DatasetFieldRow;
+import marquez.db.models.DatasetRow;
+import marquez.db.models.NamespaceRow;
+import marquez.db.models.SourceRow;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+class DatasetFieldDaoTest {
+
+  private static final String NAMESPACE = "test_namespace";
+  private static final String OWNER = "owner";
+  private static final String SOURCE = "test_source";
+  private static final String SOURCE_CONNECTION_URL = "jdbc:postgresql://localhost:5432/test";
+  private static final String DATASET = "test_dataset";
+  private static final String PHYSICAL_NAME = "physical_name";
+  private static final String DESCRIPTION = "description";
+  private static final String FIELD_NAME = "test_field";
+
+  private static DatasetFieldDao datasetFieldDao;
+  private static DatasetDao datasetDao;
+  private static NamespaceDao namespaceDao;
+  private static SourceDao sourceDao;
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    datasetFieldDao = jdbi.onDemand(DatasetFieldDao.class);
+    datasetDao = jdbi.onDemand(DatasetDao.class);
+    namespaceDao = jdbi.onDemand(NamespaceDao.class);
+    sourceDao = jdbi.onDemand(SourceDao.class);
+  }
+
+  @AfterEach
+  public void tearDown(Jdbi jdbi) {
+    JdbiUtils.cleanDatabase(jdbi);
+  }
+
+  @Test
+  void testUpsertDuplicateFieldsWithNullType(Jdbi jdbi) {
+    NamespaceRow namespace =
+        namespaceDao.upsertNamespaceRow(UUID.randomUUID(), Instant.now(), NAMESPACE, OWNER);
+
+    SourceRow source =
+        sourceDao.upsert(
+            UUID.randomUUID(), "POSTGRES", Instant.now(), SOURCE, SOURCE_CONNECTION_URL);
+
+    DatasetRow dataset =
+        datasetDao.upsert(
+            UUID.randomUUID(),
+            DatasetType.DB_TABLE,
+            Instant.now(),
+            namespace.getUuid(),
+            namespace.getName(),
+            source.getUuid(),
+            source.getName(),
+            DATASET,
+            PHYSICAL_NAME,
+            DESCRIPTION,
+            false);
+
+    UUID datasetUuid = dataset.getUuid();
+    String fieldType = null;
+
+    DatasetFieldRow row1 =
+        datasetFieldDao.upsert(
+            UUID.randomUUID(), Instant.now(), FIELD_NAME, fieldType, DESCRIPTION, datasetUuid);
+
+    DatasetFieldRow row2 =
+        datasetFieldDao.upsert(
+            UUID.randomUUID(),
+            Instant.now(),
+            FIELD_NAME,
+            fieldType,
+            "updated description",
+            datasetUuid);
+
+    Integer fieldCount =
+        jdbi.withHandle(
+            h ->
+                h.createQuery(
+                        "SELECT count(*) FROM dataset_fields WHERE dataset_uuid = :datasetUuid AND name = :name")
+                    .bind("datasetUuid", datasetUuid)
+                    .bind("name", FIELD_NAME)
+                    .mapTo(Integer.class)
+                    .one());
+
+    assertThat(fieldCount).isEqualTo(1);
+    assertThat(row1.getUuid()).isEqualTo(row2.getUuid());
+    assertThat(row1.getType()).isEqualTo("UNKNOWN");
+  }
+}


### PR DESCRIPTION
This commit fixes a critical bug where dataset fields were indefinitely duplicated when the field type was null. The root cause was the PostgreSQL ON CONFLICT clause failing to catch duplicates because NULL != NULL in standard SQL. This behavior led to an exponential explosion of rows in the column_lineage table, causing severe performance degradation.

Changes:
- Modified DatasetFieldDao.upsert to use COALESCE(:type, 'UNKNOWN') in the INSERT statement. This ensures that null types are stored as 'UNKNOWN', allowing the unique constraint (dataset_uuid, name, type) to correctly identify and update existing rows instead of inserting duplicates.
- Updated MarquezAppIntegrationTest.testDatasetWithUnknownFieldType to expect 'UNKNOWN' type for fields created with null type, reflecting the new behavior.
- Added DatasetFieldDaoTest to prevent regression by verifying that multiple upserts with null types result in a single database row.