### PR TITLE
feat: Support MARQUEZ_DB_* and POSTGRESQL_HOST environment variables #2795

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ $ cp marquez.example.yml marquez.yml
 
 You will then need to set the following environment variables (we recommend adding them to your `.bashrc`): `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`. The environment variables override the equivalent option in the configuration file.
 
+> **Note:** Marquez also supports `MARQUEZ_DB`, `MARQUEZ_DB_USER`, `MARQUEZ_DB_PASSWORD`, `MARQUEZ_DB_HOST`, and `MARQUEZ_DB_PORT` as alternatives.
+
 By default, Marquez uses the following ports:
 
 * TCP port `8080` is available for the HTTP API server.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,6 +7,28 @@
 
 set -e
 
+if [[ -n "${MARQUEZ_DB_HOST}" ]]; then
+  export POSTGRES_HOST="${MARQUEZ_DB_HOST}"
+elif [[ -n "${POSTGRESQL_HOST}" ]]; then
+  export POSTGRES_HOST="${POSTGRESQL_HOST}"
+fi
+
+if [[ -n "${MARQUEZ_DB_PORT}" ]]; then
+  export POSTGRES_PORT="${MARQUEZ_DB_PORT}"
+fi
+
+if [[ -n "${MARQUEZ_DB}" ]]; then
+  export POSTGRES_DB="${MARQUEZ_DB}"
+fi
+
+if [[ -n "${MARQUEZ_DB_USER}" ]]; then
+  export POSTGRES_USER="${MARQUEZ_DB_USER}"
+fi
+
+if [[ -n "${MARQUEZ_DB_PASSWORD}" ]]; then
+  export POSTGRES_PASSWORD="${MARQUEZ_DB_PASSWORD}"
+fi
+
 if [[ -z "${MARQUEZ_CONFIG}" ]]; then
   MARQUEZ_CONFIG='marquez.dev.yml'
   echo "WARNING 'MARQUEZ_CONFIG' not set, using development configuration."


### PR DESCRIPTION
### What change does this PR introduce?

This PR updates the Docker entrypoint script to automatically map `MARQUEZ_DB_*` and `POSTGRESQL_HOST` environment variables to the `POSTGRES_*` variables expected by the Marquez configuration.

### Why was this change needed?
#2795
Users were unable to configure the PostgreSQL connection using `MARQUEZ_DB_HOST`, `POSTGRESQL_HOST`, or related variables when deploying via Docker, as these were not recognized by the application configuration.

### How does this solve the problem?

- Modified `docker/entrypoint.sh` to check for the presence of:
  - `MARQUEZ_DB_HOST` (maps to `POSTGRES_HOST`)
  - `POSTGRESQL_HOST` (maps to `POSTGRES_HOST`)
  - `MARQUEZ_DB_PORT` (maps to `POSTGRES_PORT`)
  - `MARQUEZ_DB` (maps to `POSTGRES_DB`)
  - `MARQUEZ_DB_USER` (maps to `POSTGRES_USER`)
  - `MARQUEZ_DB_PASSWORD` (maps to `POSTGRES_PASSWORD`)
- If these variables are set, they override or set the corresponding `POSTGRES_*` variables before the application starts.
- Updated `README.md` to document these variables as supported alternatives.