### PR TITLE
fix(lineage): fix depth, facets, and dataset symlink SQL bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,31 @@
 
 ## [0.54.0](https://github.com/ilum-cloud/marquez/compare/0.53.0...0.54.0) - 2026-03-02
 
+### Added
+
+* API: **Rust backend** — complete rewrite of the Marquez API from Java/Dropwizard to **Rust** (Axum + SQLx + tokio), delivering improved performance and lower resource usage while maintaining 100% API compatibility with upstream Marquez. The Java backend (`api/`) is preserved as a fallback via `./docker/up.sh --java`. [`#14`](https://github.com/ilum-cloud/marquez/pull/14) [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+  *~38 000 lines of new Rust code across 5 workspace crates: marquez-api, marquez-search, marquez-graphql, marquez-tracing, and marquez-tests — with comprehensive DAO, service, and API integration tests plus SQL parity tests ensuring query-level equivalence with the Java implementation.*
+* API: **New** `GET` `/api/v1/search/full` advanced search returning full dataset/job objects instead of search summaries for richer client-side discovery. [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+* API: **New** `lineageStatistics` dataset facet providing upstream/downstream dependency counts and cross-team lineage visibility, computed efficiently at write time. [`#9`](https://github.com/ilum-cloud/marquez/pull/9) [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+* deploy: **AWS ECS** deployment configuration with **Terraform** — production-ready VPC, CloudFront, ECS services, and deployment scripts. [`#2`](https://github.com/ilum-cloud/marquez/pull/2) [@shunskkkk](https://github.com/shunskkkk)
+* docker: Support `MARQUEZ_DB_*` and `POSTGRESQL_HOST` env vars in Docker entrypoint for flexible database configuration. [`#12`](https://github.com/ilum-cloud/marquez/pull/12) [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+* docker: End-to-end Docker Compose stack (`docker-compose.e2e.yml`) for integration testing. [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+
 ### Changed
 
-* API: **Rewritten in Rust** — the API backend has been fully rewritten using Axum, SQLx, and tokio for improved performance and lower resource usage. The Java Dropwizard backend (`api/`) is now deprecated. [@ilum-cloud](https://github.com/ilum-cloud)
+* db: Upgrade **PostgreSQL** from 14 to **16**, **JDBI** to 3.51.0, and **Flyway** to 11.20.2, with automated migration scripts for existing deployments. [`#10`](https://github.com/ilum-cloud/marquez/pull/10) [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+* chart: Helm chart reworked — updated templates, added PodDisruptionBudget and ServiceAccount, switched image registry to `ilum`. [`#6`](https://github.com/ilum-cloud/marquez/pull/6) [`#7`](https://github.com/ilum-cloud/marquez/pull/7) [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+* docker: Docker Compose files and seed images now use `ilum` as the container organization. [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+* web: Dockerfile optimized and updated. [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+* security: Dependency vulnerability fixes across `web/`, `docs/`, and `dev/` packages. [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+
+### Fixed
+
+* API: Fix duplicate dataset fields explosion when field type is `null` — `NULL` types are now stored as `'UNKNOWN'` to satisfy the unique constraint, preventing exponential row growth in `column_lineage`. [`#8`](https://github.com/ilum-cloud/marquez/pull/8) [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+  *Resolves upstream [`#3083`](https://github.com/MarquezProject/marquez/issues/3083).*
+* chart: Use secret reference for DB password in `wait-for-db` init container instead of hardcoded value. [`#7`](https://github.com/ilum-cloud/marquez/pull/7) [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+* docker: Fix volume name normalization to lowercase on macOS. [@thijs-s](https://github.com/thijs-s) [@ilum-cloud](https://github.com/ilum-cloud)
+* docker: Add execute permission to `entrypoint.sh` for containerized environments (ECS). [@shunskkkk](https://github.com/shunskkkk)
 
 ## [0.53.0](https://github.com/ilum-cloud/marquez/compare/0.50.0...0.53.0) - 2025-08-30
 

--- a/api-rs/marquez-api/src/db/lineage.rs
+++ b/api-rs/marquez-api/src/db/lineage.rs
@@ -174,7 +174,7 @@ pub async fn get_lineage(
                 WHERE io.is_current_job_version = TRUE \
                 GROUP BY io.job_symlink_target_uuid, io.job_uuid \
             ), \
-            lineage(job_uuid, job_symlink_target_uuid, inputs, outputs) AS ( \
+            lineage(job_uuid, job_symlink_target_uuid, inputs, outputs, depth) AS ( \
                 SELECT job_uuid, job_symlink_target_uuid, \
                        COALESCE(inputs, ARRAY[]::uuid[]) AS inputs, \
                        COALESCE(outputs, ARRAY[]::uuid[]) AS outputs, \
@@ -247,7 +247,8 @@ pub async fn get_dataset_data(
     ds_uuids: &[Uuid],
 ) -> Result<Vec<DatasetDataRow>, sqlx::Error> {
     sqlx::query_as::<_, DatasetDataRow>(
-        "SELECT ds.uuid, ds.type, ds.created_at, ds.updated_at, \
+        "SELECT DISTINCT ON (ds.uuid) \
+                ds.uuid, ds.type, ds.created_at, ds.updated_at, \
                 ds.namespace_uuid, ds.namespace_name, \
                 ds.source_uuid, ds.source_name, \
                 ds.name, ds.physical_name, ds.description, \
@@ -257,8 +258,10 @@ pub async fn get_dataset_data(
          FROM datasets_view ds \
          LEFT JOIN dataset_versions dv ON dv.uuid = ds.current_version_uuid \
          LEFT JOIN dataset_symlinks dsym \
-             ON dsym.namespace_uuid = ds.namespace_uuid AND dsym.name = ds.name \
-         WHERE dsym.is_primary = true AND ds.uuid = ANY($1)",
+             ON dsym.namespace_uuid = ds.namespace_uuid \
+             AND dsym.name = ds.name \
+             AND dsym.is_primary = true \
+         WHERE ds.uuid = ANY($1)",
     )
     .bind(ds_uuids)
     .fetch_all(pool)
@@ -269,9 +272,7 @@ pub async fn get_dataset_data(
 ///
 /// Two-step approach: first resolves the dataset UUID via any matching row
 /// in `datasets_view` (which may be a symlink), then delegates to
-/// `get_dataset_data()` which filters by `is_primary = true` — ensuring
-/// we always return the primary symlink row regardless of which
-/// namespace/name alias was queried. Matches Java's `LineageDao` behaviour.
+/// `get_dataset_data()`. Matches Java's `LineageDao` behaviour.
 pub async fn get_dataset_data_by_name(
     pool: &PgPool,
     namespace_name: &str,
@@ -288,7 +289,7 @@ pub async fn get_dataset_data_by_name(
     .fetch_optional(pool)
     .await?;
 
-    // Step 2: Use get_dataset_data() which has the is_primary filter
+    // Step 2: Delegate to get_dataset_data()
     match uuid_row {
         Some((uuid,)) => get_dataset_data(pool, &[uuid]).await,
         None => Ok(vec![]),
@@ -366,11 +367,12 @@ pub async fn get_current_runs_with_facets(
         ) ri ON ri.run_uuid = r.uuid \
         LEFT JOIN LATERAL ( \
             SELECT r.uuid AS run_uuid, \
-                   (SELECT jsonb_object_agg(sub.name, sub.facet) \
-                    FROM (SELECT DISTINCT ON (rf2.name) rf2.name, rf2.facet \
+                   (SELECT jsonb_object_agg(kv.key, kv.value) \
+                    FROM (SELECT DISTINCT ON (kv2.key) kv2.key, kv2.value \
                           FROM run_facets rf2 \
+                          CROSS JOIN LATERAL jsonb_each(rf2.facet) AS kv2(key, value) \
                           WHERE rf2.run_uuid = r.uuid \
-                          ORDER BY rf2.name, rf2.lineage_event_time DESC) sub \
+                          ORDER BY kv2.key, rf2.lineage_event_time DESC) kv \
                    ) AS facets \
         ) AS f ON f.run_uuid = r.uuid \
         LEFT JOIN LATERAL ( \

--- a/api-rs/tests/src/api_tests/lineage_test.rs
+++ b/api-rs/tests/src/api_tests/lineage_test.rs
@@ -336,3 +336,198 @@ async fn lineage_graph_has_edges_after_single_event() {
         "Output dataset node should have inEdges from the producing job"
     );
 }
+
+/// Bug 1 regression: depth parameter must limit lineage traversal.
+/// A 3-job chain queried with depth=1 should NOT include the third job.
+#[tokio::test]
+async fn lineage_depth_parameter_limits_traversal() {
+    let app = TestApp::new().await;
+
+    let ns = format!("depth_ns_{}", rand::random_range(0..u32::MAX));
+    let job_a = format!("job_a_{}", rand::random_range(0..u32::MAX));
+    let job_b = format!("job_b_{}", rand::random_range(0..u32::MAX));
+    let job_c = format!("job_c_{}", rand::random_range(0..u32::MAX));
+    let ds_ab = format!("ds_ab_{}", rand::random_range(0..u32::MAX));
+    let ds_bc = format!("ds_bc_{}", rand::random_range(0..u32::MAX));
+    let run_a = generators::new_run_id();
+    let run_b = generators::new_run_id();
+    let run_c = generators::new_run_id();
+
+    let post_url = format!("{}/api/v1/lineage", app.base_url);
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+
+    // job_a COMPLETE → outputs ds_ab
+    let resp = app
+        .client
+        .post(&post_url)
+        .json(&serde_json::json!({
+            "eventType": "COMPLETE",
+            "eventTime": now,
+            "run": { "runId": run_a.to_string() },
+            "job": { "namespace": ns, "name": job_a },
+            "inputs": [],
+            "outputs": [{ "namespace": ns, "name": ds_ab }],
+            "producer": "test"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+
+    // job_b COMPLETE → inputs ds_ab, outputs ds_bc
+    let resp = app
+        .client
+        .post(&post_url)
+        .json(&serde_json::json!({
+            "eventType": "COMPLETE",
+            "eventTime": now,
+            "run": { "runId": run_b.to_string() },
+            "job": { "namespace": ns, "name": job_b },
+            "inputs": [{ "namespace": ns, "name": ds_ab }],
+            "outputs": [{ "namespace": ns, "name": ds_bc }],
+            "producer": "test"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+
+    // job_c COMPLETE → inputs ds_bc
+    let resp = app
+        .client
+        .post(&post_url)
+        .json(&serde_json::json!({
+            "eventType": "COMPLETE",
+            "eventTime": now,
+            "run": { "runId": run_c.to_string() },
+            "job": { "namespace": ns, "name": job_c },
+            "inputs": [{ "namespace": ns, "name": ds_bc }],
+            "outputs": [],
+            "producer": "test"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+
+    // depth=1 from job_a: should see job_a + ds_ab + job_b but NOT ds_bc or job_c
+    let node_id = format!("job:{}:{}", ns, job_a);
+    let url = format!(
+        "{}/api/v1/lineage?nodeId={}&depth=1",
+        app.base_url, node_id
+    );
+    let resp = app.client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    let graph = body["graph"].as_array().expect("graph array");
+    let node_ids: Vec<&str> = graph
+        .iter()
+        .filter_map(|n| n["id"].as_str())
+        .collect();
+    assert!(
+        node_ids.iter().any(|id| id.contains(&job_a)),
+        "depth=1 should include job_a"
+    );
+    assert!(
+        node_ids.iter().any(|id| id.contains(&job_b)),
+        "depth=1 should include job_b (1 hop)"
+    );
+    assert!(
+        !node_ids.iter().any(|id| id.contains(&job_c)),
+        "depth=1 should NOT include job_c (2 hops). Nodes: {:?}",
+        node_ids
+    );
+
+    // depth=10: should include all jobs
+    let deep_url = format!(
+        "{}/api/v1/lineage?nodeId={}&depth=10",
+        app.base_url, node_id
+    );
+    let resp = app.client.get(&deep_url).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    let graph = body["graph"].as_array().expect("graph array");
+    let node_ids: Vec<&str> = graph
+        .iter()
+        .filter_map(|n| n["id"].as_str())
+        .collect();
+    assert!(
+        node_ids.iter().any(|id| id.contains(&job_c)),
+        "depth=10 should include job_c. Nodes: {:?}",
+        node_ids
+    );
+}
+
+/// Bug 2 regression: facets in lineage response must be flat, not double-wrapped.
+#[tokio::test]
+async fn lineage_run_facets_are_flat() {
+    let app = TestApp::new().await;
+
+    let ns = format!("facet_ns_{}", rand::random_range(0..u32::MAX));
+    let job = generators::new_job_name();
+    let run_id = generators::new_run_id();
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+
+    // Post COMPLETE event with a run facet (sql)
+    let post_url = format!("{}/api/v1/lineage", app.base_url);
+    let resp = app
+        .client
+        .post(&post_url)
+        .json(&serde_json::json!({
+            "eventType": "COMPLETE",
+            "eventTime": now,
+            "run": {
+                "runId": run_id.to_string(),
+                "facets": {
+                    "sql": {
+                        "query": "CREATE TABLE t AS SELECT 1",
+                        "_producer": "test",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SqlJobFacet.json"
+                    }
+                }
+            },
+            "job": { "namespace": ns, "name": job },
+            "inputs": [],
+            "outputs": [],
+            "producer": "test"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+
+    // GET lineage and check the job node's latestRun facets
+    let node_id = format!("job:{}:{}", ns, job);
+    let url = format!(
+        "{}/api/v1/lineage?nodeId={}&depth=10",
+        app.base_url, node_id
+    );
+    let resp = app.client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = resp.json().await.unwrap();
+    let graph = body["graph"].as_array().expect("graph array");
+    let job_node = graph
+        .iter()
+        .find(|n| n["type"] == "JOB")
+        .expect("should have JOB node");
+
+    let latest_run = &job_node["data"]["latestRun"];
+    if !latest_run.is_null() {
+        let facets = &latest_run["facets"];
+        if !facets.is_null() && facets.get("sql").is_some() {
+            let sql_facet = &facets["sql"];
+            // Should be {"query": "...", ...}, NOT {"sql": {"query": "..."}}
+            assert!(
+                sql_facet.get("query").is_some(),
+                "sql facet should directly contain 'query', got: {}",
+                sql_facet
+            );
+            assert!(
+                sql_facet.get("sql").is_none(),
+                "sql facet should NOT be double-wrapped, got: {}",
+                facets
+            );
+        }
+    }
+}

--- a/api-rs/tests/src/db_tests/lineage_dao_test.rs
+++ b/api-rs/tests/src/db_tests/lineage_dao_test.rs
@@ -2,7 +2,9 @@
 
 use crate::common::TestDb;
 use crate::fixtures;
-use marquez_api::db::{job_version, lineage};
+use chrono::Utc;
+use marquez_api::db::{dataset_version, facets, job_version, lineage};
+use uuid::Uuid;
 
 #[tokio::test]
 async fn get_lineage_single_job() {
@@ -142,4 +144,171 @@ async fn get_lineage_empty_input() {
         .await
         .unwrap();
     assert!(result.is_empty());
+}
+
+/// Bug 1 regression: `get_lineage()` must respect the depth parameter.
+/// A 3-job chain with depth=1 should exclude the third job.
+#[tokio::test]
+async fn get_lineage_depth_limit_full_query() {
+    let db = TestDb::new().await;
+    let ns = fixtures::create_namespace(&db.pool).await;
+    let src = fixtures::create_source(&db.pool).await;
+
+    // Chain: job_1 -> ds_1 -> job_2 -> ds_2 -> job_3
+    let job_1 = fixtures::create_job(&db.pool, &ns).await;
+    let job_2 = fixtures::create_job(&db.pool, &ns).await;
+    let job_3 = fixtures::create_job(&db.pool, &ns).await;
+    let ds_1 = fixtures::create_dataset(&db.pool, &ns, &src).await;
+    let ds_2 = fixtures::create_dataset(&db.pool, &ns, &src).await;
+
+    let jv_1 = fixtures::create_job_version(&db.pool, &job_1).await;
+    let jv_2 = fixtures::create_job_version(&db.pool, &job_2).await;
+    let jv_3 = fixtures::create_job_version(&db.pool, &job_3).await;
+
+    job_version::upsert_output_dataset(&db.pool, jv_1.uuid, ds_1.uuid, job_1.uuid, None)
+        .await
+        .unwrap();
+    job_version::upsert_input_dataset(&db.pool, jv_2.uuid, ds_1.uuid, job_2.uuid, None)
+        .await
+        .unwrap();
+    job_version::upsert_output_dataset(&db.pool, jv_2.uuid, ds_2.uuid, job_2.uuid, None)
+        .await
+        .unwrap();
+    job_version::upsert_input_dataset(&db.pool, jv_3.uuid, ds_2.uuid, job_3.uuid, None)
+        .await
+        .unwrap();
+
+    // depth=1: should find job_1 + job_2 but NOT job_3
+    let shallow = lineage::get_lineage(&db.pool, 1, &[job_1.uuid])
+        .await
+        .unwrap();
+    let shallow_uuids: Vec<_> = shallow.iter().map(|j| j.uuid).collect();
+    assert!(
+        shallow_uuids.contains(&job_1.uuid),
+        "depth=1 should include seed job"
+    );
+    assert!(
+        shallow_uuids.contains(&job_2.uuid),
+        "depth=1 should include 1-hop neighbor"
+    );
+    assert!(
+        !shallow_uuids.contains(&job_3.uuid),
+        "depth=1 should NOT include 2-hop neighbor"
+    );
+
+    // depth=10: should find all three
+    let deep = lineage::get_lineage(&db.pool, 10, &[job_1.uuid])
+        .await
+        .unwrap();
+    let deep_uuids: Vec<_> = deep.iter().map(|j| j.uuid).collect();
+    assert!(deep_uuids.contains(&job_1.uuid));
+    assert!(deep_uuids.contains(&job_2.uuid));
+    assert!(deep_uuids.contains(&job_3.uuid));
+}
+
+/// Bug 2 regression: `get_current_runs_with_facets()` must return flat
+/// facets, not double-wrapped `{"sql": {"sql": {...}}}`.
+#[tokio::test]
+async fn get_current_runs_with_facets_flat_format() {
+    use marquez_api::db::{job, run};
+
+    let db = TestDb::new().await;
+    let ns = fixtures::create_namespace(&db.pool).await;
+    let job_row = fixtures::create_job(&db.pool, &ns).await;
+    let jv = fixtures::create_job_version(&db.pool, &job_row).await;
+
+    // Create a run with job_version_uuid set (required by the INNER JOIN)
+    let now = Utc::now();
+    let run_row = run::upsert(
+        &db.pool,
+        Uuid::new_v4(),
+        now,
+        Some(job_row.uuid),
+        Some(jv.uuid),
+        None,
+        None,
+        None,
+        None,
+        Some("COMPLETED"),
+        Some(now),
+        None,
+        Some(now),
+        None,
+        job_row.namespace_name.as_deref().unwrap_or("default"),
+        &job_row.name,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Point the job's current_run_uuid at this run
+    job::update_current_run(&db.pool, job_row.uuid, run_row.uuid, now)
+        .await
+        .unwrap();
+
+    let facet_value = serde_json::json!({"sql": {"query": "SELECT 1"}});
+    facets::insert_run_facet(&db.pool, now, run_row.uuid, now, "COMPLETE", "sql", &facet_value)
+        .await
+        .unwrap();
+
+    let rows = lineage::get_current_runs_with_facets(&db.pool, &[job_row.uuid])
+        .await
+        .unwrap();
+    assert!(!rows.is_empty(), "should return at least one run");
+
+    let row = &rows[0];
+    let facets_json = row.facets.as_ref().expect("facets should not be null");
+
+    // The facets should be flat: {"sql": {"query": "SELECT 1"}}
+    // NOT double-wrapped: {"sql": {"sql": {"query": "SELECT 1"}}}
+    let sql_facet = facets_json.get("sql").expect("should have 'sql' key");
+    assert!(
+        sql_facet.get("query").is_some(),
+        "sql facet should directly contain 'query', got: {}",
+        sql_facet
+    );
+    assert!(
+        sql_facet.get("sql").is_none(),
+        "sql facet should NOT be double-wrapped, got: {}",
+        facets_json
+    );
+}
+
+/// Bug 3 regression: `get_dataset_data()` must return datasets even when
+/// they have a non-primary symlink (LEFT JOIN semantics).
+#[tokio::test]
+async fn get_dataset_data_with_non_primary_symlink() {
+    let db = TestDb::new().await;
+    let ns = fixtures::create_namespace(&db.pool).await;
+    let src = fixtures::create_source(&db.pool).await;
+
+    // create_dataset already creates a primary symlink
+    let ds = fixtures::create_dataset(&db.pool, &ns, &src).await;
+
+    // Add a non-primary symlink for the same dataset
+    let alias_name = format!("alias_{}", uuid::Uuid::new_v4());
+    dataset_version::upsert_symlink(
+        &db.pool,
+        ds.uuid,
+        &alias_name,
+        ns.uuid,
+        None,
+        false,
+        Utc::now(),
+    )
+    .await
+    .unwrap();
+
+    // Should still return the dataset (not filtered out by non-primary symlink)
+    let result = lineage::get_dataset_data(&db.pool, &[ds.uuid])
+        .await
+        .unwrap();
+    assert_eq!(
+        result.len(),
+        1,
+        "dataset with non-primary symlink should still be returned (got {} rows)",
+        result.len()
+    );
+    assert_eq!(result[0].uuid, ds.uuid);
 }


### PR DESCRIPTION
  - **Depth ignored**: The `lineage` recursive CTE declared 4 column names
    but produced 5 columns (including `depth`), causing a PostgreSQL error.                                                                                                                   
    Added `depth` to the CTE column list.                                  
  - **Facets double-wrapped**: `get_current_runs_with_facets()` used                                                                                                                          
    `jsonb_object_agg(name, facet)` which produced                  
    `{"sql": {"sql": {...}}}`. Replaced with the `jsonb_each()` unwrap                                                                                                                        
    pattern used elsewhere in the codebase.                                                                                                                                                   
  - **CTAS datasets missing**: `get_dataset_data()` placed `is_primary = true`                                                                                                                
    in the WHERE clause, converting the LEFT JOIN into an effective INNER JOIN.                                                                                                               
    Moved the condition into the JOIN ON clause and added `DISTINCT ON`.