### PR TITLE
fix(web): single-encode nodeId for URI-shaped namespaces

### DIFF
--- a/web/src/__tests__/requests/columnlineage.test.ts
+++ b/web/src/__tests__/requests/columnlineage.test.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as requestUtils from '../../store/requests'
-import { getLineage } from '../../store/requests/lineage'
+import { getColumnLineage } from '../../store/requests/columnlineage'
 
-describe('getLineage', () => {
+describe('getColumnLineage', () => {
   let spy: jest.SpyInstance<Promise<any>, [string, requestUtils.IParams, string]>
 
   beforeEach(() => {
@@ -14,16 +14,18 @@ describe('getLineage', () => {
   const queryFor = (url: string) => url.split('?').pop()!.split('&')
 
   it('single-encodes the nodeId for URI-shaped namespaces', () => {
-    getLineage('DATASET', 's3://test-bucket', 'manual-out/', 2)
+    getColumnLineage('DATASET', 's3://test-bucket', 'manual-out/', 2)
     const params = queryFor(spy.mock.lastCall[0])
     expect(params).toContain('nodeId=dataset%3As3%3A%2F%2Ftest-bucket%3Amanual-out%2F')
     expect(params).toContain('depth=2')
+    expect(params).toContain('withDownstream=true')
   })
 
   it('single-encodes the nodeId for simple namespaces', () => {
-    getLineage('JOB', 'foo', 'bar', 0)
+    getColumnLineage('JOB', 'foo', 'bar', 0)
     const params = queryFor(spy.mock.lastCall[0])
     expect(params).toContain('nodeId=job%3Afoo%3Abar')
     expect(params).toContain('depth=0')
+    expect(params).toContain('withDownstream=true')
   })
 })

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -239,7 +239,7 @@ const Datasets: React.FC<DatasetsProps> = ({
                               <MqText
                                 link
                                 linkTo={`column-level/${encodeURIComponent(
-                                  encodeURIComponent(dataset.id.namespace)
+                                  dataset.id.namespace
                                 )}/${encodeURIComponent(dataset.id.name)}`}
                               >
                                 VIEW

--- a/web/src/store/requests/columnlineage.ts
+++ b/web/src/store/requests/columnlineage.ts
@@ -15,9 +15,9 @@ export const getColumnLineage = async (
   name: string,
   depth: number
 ) => {
-  const encodedNamespace = encodeURIComponent(namespace)
-  const encodedName = encodeURIComponent(name)
-  const nodeId = generateNodeId(nodeType, encodedNamespace, encodedName)
-  const url = `${API_URL}/column-lineage?nodeId=${nodeId}&depth=${depth}&withDownstream=true`
+  const nodeId = generateNodeId(nodeType, namespace, name)
+  const url =
+    `${API_URL}/column-lineage?nodeId=${encodeURIComponent(nodeId)}` +
+    `&depth=${depth}&withDownstream=true`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchColumnLineage')
 }

--- a/web/src/store/requests/lineage.ts
+++ b/web/src/store/requests/lineage.ts
@@ -12,9 +12,7 @@ export const getLineage = async (
   name: string,
   depth: number
 ) => {
-  const encodedNamespace = encodeURIComponent(namespace)
-  const encodedName = encodeURIComponent(name)
-  const nodeId = generateNodeId(nodeType, encodedNamespace, encodedName)
-  const url = `${API_URL}/lineage?nodeId=${nodeId}&depth=${depth}`
+  const nodeId = generateNodeId(nodeType, namespace, name)
+  const url = `${API_URL}/lineage?nodeId=${encodeURIComponent(nodeId)}&depth=${depth}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchLineage')
 }


### PR DESCRIPTION
## Summary

Column-lineage and lineage UI views returned **404** for any dataset whose namespace contained `:`, i.e. every spec-compliant OpenLineage namespace (`s3://`, `gs://`, `abfss://`, `hdfs://`, `jdbc:postgres://...`). The dataset itself, its `columnLineage` facet, and the dataset-level lineage graph all existed; only the graph endpoints failed.

Two encoding bugs combined to corrupt the `nodeId` on the wire. Both are fixed in this PR; no backend change was required.

Closes the regression first reported in `COLUMN_LINEAGE_NODEID_BUG.md` (this fork) and addresses upstream [MarquezProject/marquez#1761](https://github.com/MarquezProject/marquez/issues/1761).

## Root cause

1. **Request-layer double-encoding.** `getColumnLineage` and `getLineage` in `web/src/store/requests/` percent-encoded `namespace` and `name` as separate components, concatenated them with raw `:` delimiters via `generateNodeId`, then interpolated the resulting string into the URL. The canonical contract for `encodeURIComponent` is "encode a query *value*", not its pieces, and any layer that subsequently re-encodes pre-encoded `%XX` sequences turns `%3A` into `%253A`.

2. **Route-link double-encoding.** `routes/datasets/Datasets.tsx` wrapped `dataset.id.namespace` in `encodeURIComponent` **twice** when building the column-level link. After react-router decoded the path param once, the `ColumnLevel` component received a still-encoded namespace (`s3%3A//test-bucket`), which then flowed into the request layer.

The two bugs were independent but compounded: fixing only the request layer left the route-link bug visible (the symptom in manual testing was a `nodeId=...s3%253A%2F%2F...` even after the request fix).

## Changes

**Request layer** (`web/src/store/requests/`):

- `columnlineage.ts`: build the raw `nodeId`, then `encodeURIComponent` the whole string once at the URL boundary.
- `lineage.ts`: same change.

**Route link** (`web/src/routes/datasets/Datasets.tsx`):

- Drop the inner `encodeURIComponent` in the column-level `linkTo`. The path is now single-encoded; react-router decodes once and `useParams()` returns the raw namespace.

**Tests** (`web/src/__tests__/requests/`):

- `lineage.test.ts` rewritten. The prior test (`'does not url-encode query params'`) hard-coded the buggy contract. New cases assert the single-encoded URL for both URI-shaped (`s3://test-bucket` / `manual-out/`) and simple (`foo` / `bar`) inputs.
- `columnlineage.test.ts` added, mirroring the lineage tests and also asserting `&depth=N&withDownstream=true` are still present.