### PR TITLE
fix(docker): make the Docker scripts work when invoked via sh on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Normalize line endings so a Windows checkout cannot break the Docker stack.
+#
+# With Git's default `core.autocrlf=true` on Windows, these files are checked out
+# with CRLF. That breaks them twice over: the host shell fails to run them
+# ("/bin/bash^M: bad interpreter"), and the Dockerfile COPYs entrypoint.sh and
+# wait-for-it.sh into the image, so the containers inherit the same failure.
+# Forcing eol=lf here makes the checkout correct regardless of a user's
+# core.autocrlf setting.
+
+*.sh                    text eol=lf
+Dockerfile*             text eol=lf
+*.yml                   text eol=lf
+*.yaml                  text eol=lf
+docker/postgresql.conf  text eol=lf
+gradlew                 text eol=lf

--- a/README.md
+++ b/README.md
@@ -51,19 +51,23 @@ $ ./docker/up.sh
 
 ### Windows users:
 
-Before cloning Marquez, configure Git to check out files with Unix-style file endings:
-
-```bash
-$ git config --global core.autocrlf false
-```
-
-Verify that Bash and PostgreSQL have been installed and added to the PATH variable (Git Bash is recommended).
+Marquez is started through Bash scripts, so you need Bash on your PATH. Either [WSL2](https://learn.microsoft.com/windows/wsl/install) (recommended, and already used by Docker Desktop) or Git Bash works.
 
 Start all services:
 
 ```bash
-$ sh ./docker/up.sh
+$ ./docker/up.sh
 ```
+
+If the script is not marked executable in your checkout, invoke it explicitly with Bash:
+
+```bash
+$ bash ./docker/up.sh
+```
+
+> **Note:** Use `bash`, not `sh`. On WSL and Ubuntu `/bin/sh` is `dash`, which does not support the `[[ ]]` syntax these scripts use. The scripts now re-exec themselves under Bash automatically, but in older checkouts `sh ./docker/up.sh` prints `[[: not found`, skips volume provisioning, and `marquez-db` then exits with `could not access the server configuration file "/etc/postgresql/postgresql.conf"`.
+
+> **Note:** Line endings are pinned to LF via [`.gitattributes`](./.gitattributes). If you cloned before that file was added and the scripts fail with `bad interpreter: /bin/bash^M`, run `git config --global core.autocrlf false` and re-clone.
 
 > **Tip:** Use the `--build` flag to build images from source, and/or `--seed` to start Marquez with sample lineage metadata. For a more complete example using the sample metadata, please follow our [quickstart](https://marquezproject.github.io/marquez/quickstart.html) guide.
 

--- a/docker/down.sh
+++ b/docker/down.sh
@@ -5,6 +5,16 @@
 #
 # Usage: $ ./down.sh [FLAGS]
 
+# This script uses bash features (`+=`, `${RANDOM}`) that POSIX shells do not
+# implement. Re-exec under bash so `sh ./docker/down.sh` works too (see up.sh).
+if [ -z "${BASH_VERSION:-}" ]; then
+  if ! command -v bash > /dev/null 2>&1; then
+    echo "ERROR: ./docker/down.sh requires bash, but bash was not found on PATH." >&2
+    exit 1
+  fi
+  exec bash "$0" "$@"
+fi
+
 set -e
 
 title() {

--- a/docker/migrate-db.sh
+++ b/docker/migrate-db.sh
@@ -5,6 +5,16 @@
 #
 # Usage: $ ./migrate-db.sh [backup|restore] [FLAGS]
 
+# This script uses bash features (`[[ ]]`) that POSIX shells do not implement.
+# Re-exec under bash so `sh ./docker/migrate-db.sh` works too (see up.sh).
+if [ -z "${BASH_VERSION:-}" ]; then
+  if ! command -v bash > /dev/null 2>&1; then
+    echo "ERROR: ./docker/migrate-db.sh requires bash, but bash was not found on PATH." >&2
+    exit 1
+  fi
+  exec bash "$0" "$@"
+fi
+
 set -e
 
 title() {

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -203,8 +203,10 @@ fi
 # Check for Postgres version incompatibility
 VOLUME_NAME="${PROJECT_NAME}_db-backup"
 if docker volume inspect "${VOLUME_NAME}" > /dev/null 2>&1; then
-  # Check PG_VERSION
-  PG_VERSION=$(docker run --rm -v "${VOLUME_NAME}:/data" busybox cat /data/PG_VERSION 2>/dev/null || echo "")
+  # Check PG_VERSION. MSYS_NO_PATHCONV stops Git Bash rewriting the container-side
+  # /data into a Windows path, which made this read fail silently and left
+  # PG_VERSION empty, disabling the incompatibility check entirely on Windows.
+  PG_VERSION=$(MSYS_NO_PATHCONV=1 docker run --rm -v "${VOLUME_NAME}:/data" busybox cat /data/PG_VERSION 2>/dev/null || echo "")
   if [[ -n "$PG_VERSION" && "$PG_VERSION" -lt 16 ]]; then
     echo -e "\033[0;31mERROR: Incompatible PostgreSQL version detected ($PG_VERSION) in volume '${VOLUME_NAME}'.\033[0m"
     echo -e "\033[0;31mMarquez now requires PostgreSQL 16.\033[0m"

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -5,6 +5,20 @@
 #
 # Usage: $ ./up.sh [FLAGS] [ARG...]
 
+# This script uses bash features (`[[ ]]`, `+=`) that POSIX shells do not implement.
+# On Debian/Ubuntu (including WSL) /bin/sh is dash, so `sh ./docker/up.sh` would
+# silently skip every conditional below -- most importantly the call to
+# ./docker/volumes.sh -- and bring the stack up with unprovisioned volumes, making
+# postgres exit with 'could not access the server configuration file'. Re-exec
+# under bash so the script behaves identically however it is invoked.
+if [ -z "${BASH_VERSION:-}" ]; then
+  if ! command -v bash > /dev/null 2>&1; then
+    echo "ERROR: ./docker/up.sh requires bash, but bash was not found on PATH." >&2
+    exit 1
+  fi
+  exec bash "$0" "$@"
+fi
+
 set -e
 
 # Version of Marquez

--- a/docker/volumes.sh
+++ b/docker/volumes.sh
@@ -23,10 +23,13 @@ title() {
   echo -e "\033[1m${1}\033[0m"
 }
 
-# No `-it` here: allocating a TTY fails under Git Bash and in non-interactive
-# environments (CI, piped output) with 'the input device is not a TTY'.
+# No `-it` here: it fails with 'the input device is not a TTY' whenever stdin is
+# not a terminal (CI, piped output), and a TTY is pointless for a one-shot ls.
+# MSYS_NO_PATHCONV stops Git Bash rewriting the container-side /tmp into a Windows
+# path, which made this print a "No such file or directory" error instead of the
+# volume contents, so provisioning looked like it had failed when it had not.
 ls() {
-  docker run --rm -v "${1}:/tmp" busybox ls /tmp
+  MSYS_NO_PATHCONV=1 docker run --rm -v "${1}:/tmp" busybox ls /tmp
 }
 
 usage() {

--- a/docker/volumes.sh
+++ b/docker/volumes.sh
@@ -5,12 +5,28 @@
 #
 # Usage: $ ./volumes.sh <volume-prefix>
 
+# This script uses bash features (`[[ ]]`) that POSIX shells do not implement.
+# Re-exec under bash so `sh ./docker/volumes.sh` works too (see up.sh).
+if [ -z "${BASH_VERSION:-}" ]; then
+  if ! command -v bash > /dev/null 2>&1; then
+    echo "ERROR: ./docker/volumes.sh requires bash, but bash was not found on PATH." >&2
+    exit 1
+  fi
+  exec bash "$0" "$@"
+fi
+
+# Fail loudly: if provisioning does not complete, postgres later dies with the
+# confusing 'could not access the server configuration file' error instead.
+set -e
+
 title() {
   echo -e "\033[1m${1}\033[0m"
 }
 
+# No `-it` here: allocating a TTY fails under Git Bash and in non-interactive
+# environments (CI, piped output) with 'the input device is not a TTY'.
 ls() {
-  docker run -it --rm -v "${1}:/tmp" busybox ls /tmp
+  docker run --rm -v "${1}:/tmp" busybox ls /tmp
 }
 
 usage() {
@@ -52,12 +68,17 @@ docker volume create "${db_init_volume}" > /dev/null
 docker volume create "${db_backup_volume}" > /dev/null
 docker volume create "${opensearch_volume}" > /dev/null
 
-# Provision persistent volumes for Marquez
+# Remove a provisioner left behind by an interrupted run, otherwise the
+# `docker create` below fails on the duplicate container name.
+docker rm -f volumes-provisioner > /dev/null 2>&1 || true
+
+# Provision persistent volumes for Marquez (stderr is left visible so a failure
+# here is reported rather than swallowed)
 docker create --name volumes-provisioner \
   -v "${data_volume}:/data" \
   -v "${db_conf_volume}:/db-conf" \
   -v "${db_init_volume}:/db-init" \
-  busybox > /dev/null 2>&1
+  busybox > /dev/null
 
 # Add startup configuration for Marquez
 docker cp ./docker/wait-for-it.sh volumes-provisioner:/data/wait-for-it.sh


### PR DESCRIPTION
Fixes a reported failure where `./docker/up.sh` brings the stack up on Windows but `marquez-db` immediately exits with:

  ```
  postgres: could not access the server configuration file "/etc/postgresql/postgresql.conf": No such file or directory
  marquez-db exited with code 2
  ```

  followed by the API failing with `No address associated with hostname`.

  Neither error is the real fault. The root cause is that the scripts were run as `sh ./docker/up.sh`, which is what the README told Windows users to do.

  ## Root cause

  `up.sh` has a `#!/bin/bash` shebang but uses bash-only syntax (`[[ ]]`, `+=`). Invoking it as `sh ./docker/up.sh` runs it under whatever `/bin/sh` is. On Debian, Ubuntu and WSL that is
  **dash**, which has no `[[ ]]`, so all nine conditionals fail with `[[: not found`.

  The failure is silent. A failing `[[` inside an `if` condition simply makes the condition false, and the `if` still exits 0, so `set -e` never fires. The script continues with **every 
  `then` branch skipped**, including the call to `./docker/volumes.sh`.

  That call is what copies `postgresql.conf`, `init-db.sh` and `wait-for-it.sh` into the named volumes. Skipped, Compose creates those volumes empty. Postgres then starts with `-c
  config_file=/etc/postgresql/postgresql.conf`, the file is not there, and it exits 2. The database container dying is why `db` stops resolving, so the API's `No address associated with
  hostname` is only a downstream symptom.

  A tell in the original report confirms it: only `marquez-db` and `marquez-api` were created, with no web or opensearch container, because the `NO_WEB` and `NO_SEARCH` guards silently
  failed too.

  This instruction was written for Git Bash, where `sh` is bash in POSIX mode and `[[ ]]` works fine. It only breaks on WSL and Linux, where `sh` is dash.

  ## Changes

  **Re-exec under bash** in `up.sh`, `down.sh`, `volumes.sh` and `migrate-db.sh`, so they behave identically however they are invoked. `down.sh` was broken under `sh` too, dying at
  `compose_args+=` with exit 127, which also blocked the obvious cleanup path.

  **`.gitattributes`** pinning `*.sh`, `Dockerfile*` and compose files to `eol=lf`. With Git's default `core.autocrlf=true` on Windows these are checked out with CRLF, which breaks the
  shebang on the host and inside the images that `COPY` `entrypoint.sh` and `wait-for-it.sh`. This removes the need for the manual `git config --global core.autocrlf false` step. No existing
  file changes, since nothing in the repo currently has CRLF.

  **`MSYS_NO_PATHCONV`** on the two `docker run` calls that reference a container-side path. Git Bash rewrites Unix-looking arguments into Windows paths before passing them to `docker.exe`,
  so `-v vol:/data busybox cat /data/PG_VERSION` actually ran as `cat C:/Users/<user>/.../data/PG_VERSION`.

  In `up.sh` this silently disabled the PostgreSQL 16 incompatibility check: the read always failed, `PG_VERSION` stayed empty, and a Windows user upgrading from an old PG 14 volume got a
  confusing postgres crash instead of the migration instructions. In `volumes.sh` it made successful provisioning print `No such file or directory` where the file names belong. Verified that
  the files themselves do land correctly; only the listing and the version check were wrong.

  **`volumes.sh` hardening**: `set -e` so a provisioning failure surfaces there instead of as a confusing postgres error later, dropped `docker run -it` (fails with `the input device is not
  a TTY` whenever stdin is not a terminal, such as CI or piped output), removal of a provisioner container left behind by an interrupted run, and stderr from `docker create` is no longer
  discarded.

  **README** Windows section updated to use `bash` rather than `sh`, with both failure signatures documented.

  ## Testing

  Validated on Linux and Windows at the same commit.

  **Linux** (`/bin/sh -> dash`, Docker 29.2.1): 14/14 passed.

  - Control: `origin/main`'s `up.sh` still produces 9 `[[: not found` here, so the harness genuinely detects the bug
  - `sh`, `dash`, `bash` and direct invocation of `up.sh`: 0 occurrences each
  - `down.sh -v`, `volumes.sh` under `sh`: exit 0 (`down.sh` was exit 127 before)
  - `docker run -it` with non-tty stdin: `the input device is not a TTY` before, correct listing after

  **Re-exec under bash** in `up.sh`, `down.sh`, `volumes.sh` and `migrate-db.sh`, so they behave identically however they are invoked. `down.sh` was broken under `sh` too, dying at
  `compose_args+=` with exit 127, which also blocked the obvious cleanup path.

  **`.gitattributes`** pinning `*.sh`, `Dockerfile*` and compose files to `eol=lf`. With Git's default `core.autocrlf=true` on Windows these are checked out with CRLF, which breaks the
  shebang on the host and inside the images that `COPY` `entrypoint.sh` and `wait-for-it.sh`. This removes the need for the manual `git config --global core.autocrlf false` step. No existing
  file changes, since nothing in the repo currently has CRLF.

  **`MSYS_NO_PATHCONV`** on the two `docker run` calls that reference a container-side path. Git Bash rewrites Unix-looking arguments into Windows paths before passing them to `docker.exe`,
  so `-v vol:/data busybox cat /data/PG_VERSION` actually ran as `cat C:/Users/<user>/.../data/PG_VERSION`.

  In `up.sh` this silently disabled the PostgreSQL 16 incompatibility check: the read always failed, `PG_VERSION` stayed empty, and a Windows user upgrading from an old PG 14 volume got a
  confusing postgres crash instead of the migration instructions. In `volumes.sh` it made successful provisioning print `No such file or directory` where the file names belong. Verified that
  the files themselves do land correctly; only the listing and the version check were wrong.

  **`volumes.sh` hardening**: `set -e` so a provisioning failure surfaces there instead of as a confusing postgres error later, dropped `docker run -it` (fails with `the input device is not
  a TTY` whenever stdin is not a terminal, such as CI or piped output), removal of a provisioner container left behind by an interrupted run, and stderr from `docker create` is no longer
  discarded.

  **README** Windows section updated to use `bash` rather than `sh`, with both failure signatures documented.

  ## Testing

  Validated on Linux and Windows at the same commit.

  **Linux** (`/bin/sh -> dash`, Docker 29.2.1): 14/14 passed.

  - Control: `origin/main`'s `up.sh` still produces 9 `[[: not found` here, so the harness genuinely detects the bug
  - `sh`, `dash`, `bash` and direct invocation of `up.sh`: 0 occurrences each
  - `down.sh -v`, `volumes.sh` under `sh`: exit 0 (`down.sh` was exit 127 before)
  - `docker run -it` with non-tty stdin: `the input device is not a TTY` before, correct listing after
  - Full stack up, `{"status":"healthy"}`, postgres confirmed loading `/etc/postgresql/postgresql.conf`

  **Windows 10** (Git Bash / MSYS2, git 2.55.0, Docker 29.6.2, Compose v5.3.1, matching the reporter's versions): 26/26 passed.

  - `core.autocrlf: true`, yet 0 CR bytes in all six shell scripts and the Dockerfile
  - `sh` is bash 5.3.15, so the guard is correctly a no-op; 0 occurrences of `[[: not found`
  - `PG_VERSION` reads `14` with the fix, versus `cat: can't open 'C:/Users/.../data/PG_VERSION'` without it
  - Provisioning listing correct and volume contents independently verified
  - Full seeded stack up: db, api and web all running, healthy, web HTTP 200, `marquez` database created, seed job exit 0, `food_delivery` namespace present, lineage graph rendering in the
  browser

  Every element of the original failure is inverted: no `[[: not found`, volumes provisioned, `marquez-db` up instead of `Exited (2)`, postgres loading its config file instead of dying on
  it, and the API connected instead of failing to resolve `db`.

  One coverage gap worth stating: the Windows leg ran through Git Bash, not WSL2. WSL2 with Ubuntu was installed on the test VM but would not boot (Ubuntu 26.04 image inside an already
  nested VM). The reporter is on WSL2, where `/bin/sh` is dash, and that exact path is what the Linux leg covers with an identical userland. Both stack tests used `--no-search`, so
  OpenSearch is not in this matrix.

  ## Notes

  `MSYS_NO_PATHCONV` is ignored outside MSYS, so it is a no-op on Linux and macOS. No behaviour changes for existing Linux or macOS users; the bash guard does not fire when the script is
  already running under bash