### PR TITLE
feat: DB config from existing secret (chart) and Rust entrypoint precedence fix

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,13 +2,13 @@ name: Rust CI
 
 on:
   push:
-    branches: [rust]
+    branches: [main]
     paths:
       - 'api-rs/**'
       - 'Dockerfile'
       - '.github/workflows/rust-ci.yml'
   pull_request:
-    branches: [rust]
+    branches: [main]
     paths:
       - 'api-rs/**'
       - 'Dockerfile'

--- a/api-rs/marquez-api/src/config.rs
+++ b/api-rs/marquez-api/src/config.rs
@@ -24,6 +24,22 @@ fn default_db_port() -> u16 {
     5432
 }
 
+fn default_db_host() -> String {
+    "localhost".to_string()
+}
+
+fn default_db_name() -> String {
+    "marquez".to_string()
+}
+
+fn default_db_user() -> String {
+    "marquez".to_string()
+}
+
+fn default_db_password() -> String {
+    "marquez".to_string()
+}
+
 fn default_pool_size() -> u32 {
     10
 }
@@ -42,6 +58,7 @@ fn default_retention_days() -> i32 {
 
 #[derive(Debug, Deserialize)]
 pub struct MarquezConfig {
+    #[serde(default)]
     pub db: DbConfig,
     #[serde(default)]
     pub server: ServerConfig,
@@ -102,14 +119,31 @@ impl Default for ServerConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct DbConfig {
+    #[serde(default = "default_db_host")]
     pub host: String,
     #[serde(default = "default_db_port")]
     pub port: u16,
+    #[serde(default = "default_db_name")]
     pub name: String,
+    #[serde(default = "default_db_user")]
     pub user: String,
+    #[serde(default = "default_db_password")]
     pub password: String,
     #[serde(default = "default_pool_size")]
     pub max_pool_size: u32,
+}
+
+impl Default for DbConfig {
+    fn default() -> Self {
+        Self {
+            host: default_db_host(),
+            port: default_db_port(),
+            name: default_db_name(),
+            user: default_db_user(),
+            password: default_db_password(),
+            max_pool_size: default_pool_size(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/api-rs/tests/src/api_tests/lineage_test.rs
+++ b/api-rs/tests/src/api_tests/lineage_test.rs
@@ -412,18 +412,12 @@ async fn lineage_depth_parameter_limits_traversal() {
 
     // depth=1 from job_a: should see job_a + ds_ab + job_b but NOT ds_bc or job_c
     let node_id = format!("job:{}:{}", ns, job_a);
-    let url = format!(
-        "{}/api/v1/lineage?nodeId={}&depth=1",
-        app.base_url, node_id
-    );
+    let url = format!("{}/api/v1/lineage?nodeId={}&depth=1", app.base_url, node_id);
     let resp = app.client.get(&url).send().await.unwrap();
     assert_eq!(resp.status(), 200);
     let body: Value = resp.json().await.unwrap();
     let graph = body["graph"].as_array().expect("graph array");
-    let node_ids: Vec<&str> = graph
-        .iter()
-        .filter_map(|n| n["id"].as_str())
-        .collect();
+    let node_ids: Vec<&str> = graph.iter().filter_map(|n| n["id"].as_str()).collect();
     assert!(
         node_ids.iter().any(|id| id.contains(&job_a)),
         "depth=1 should include job_a"
@@ -447,10 +441,7 @@ async fn lineage_depth_parameter_limits_traversal() {
     assert_eq!(resp.status(), 200);
     let body: Value = resp.json().await.unwrap();
     let graph = body["graph"].as_array().expect("graph array");
-    let node_ids: Vec<&str> = graph
-        .iter()
-        .filter_map(|n| n["id"].as_str())
-        .collect();
+    let node_ids: Vec<&str> = graph.iter().filter_map(|n| n["id"].as_str()).collect();
     assert!(
         node_ids.iter().any(|id| id.contains(&job_c)),
         "depth=10 should include job_c. Nodes: {:?}",

--- a/api-rs/tests/src/api_tests/openlineage_test.rs
+++ b/api-rs/tests/src/api_tests/openlineage_test.rs
@@ -1408,12 +1408,11 @@ async fn streaming_heartbeat_preserves_io_mappings() {
 
     // Lineage should still show the datasets from START
     let graph = get_lineage_graph(&app, &ns, &job_name).await;
-    let job_node = graph
-        .iter()
-        .find(|n| n["type"] == "JOB")
-        .expect("job node");
+    let job_node = graph.iter().find(|n| n["type"] == "JOB").expect("job node");
     let inputs = job_node["data"]["inputs"].as_array().expect("inputs array");
-    let outputs = job_node["data"]["outputs"].as_array().expect("outputs array");
+    let outputs = job_node["data"]["outputs"]
+        .as_array()
+        .expect("outputs array");
 
     assert_eq!(
         inputs.len(),

--- a/api-rs/tests/src/db_tests/lineage_dao_test.rs
+++ b/api-rs/tests/src/db_tests/lineage_dao_test.rs
@@ -248,9 +248,17 @@ async fn get_current_runs_with_facets_flat_format() {
         .unwrap();
 
     let facet_value = serde_json::json!({"sql": {"query": "SELECT 1"}});
-    facets::insert_run_facet(&db.pool, now, run_row.uuid, now, "COMPLETE", "sql", &facet_value)
-        .await
-        .unwrap();
+    facets::insert_run_facet(
+        &db.pool,
+        now,
+        run_row.uuid,
+        now,
+        "COMPLETE",
+        "sql",
+        &facet_value,
+    )
+    .await
+    .unwrap();
 
     let rows = lineage::get_current_runs_with_facets(&db.pool, &[job_row.uuid])
         .await

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -18,7 +18,7 @@ keywords:
 sources:
   - https://github.com/ilum-cloud/marquez
   - https://ilum.cloud/
-version: 0.54.0
+version: 0.54.1
 
 annotations:
   artifacthub.io/prerelease: "false"

--- a/chart/README.md
+++ b/chart/README.md
@@ -40,6 +40,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `marquez.image.tag`           | Image tag                                            | `0.54.0`                               |
 | `marquez.image.pullPolicy`    | Image pull policy                                    | `IfNotPresent`                         |
 | `marquez.existingSecretName`  | Name of existing secret for DB credentials           | `""`                                   |
+| `marquez.existingSecretKeys.passwordKey`  | Secret key holding the DB password       | `marquez-db-password`                  |
+| `marquez.existingSecretKeys.hostKey`      | Secret key holding the DB host (optional)     | `""`                              |
+| `marquez.existingSecretKeys.portKey`      | Secret key holding the DB port (optional)     | `""`                              |
+| `marquez.existingSecretKeys.databaseKey`  | Secret key holding the DB name (optional)     | `""`                              |
+| `marquez.existingSecretKeys.userKey`      | Secret key holding the DB user (optional)     | `""`                              |
+| `marquez.extraEnv`            | Additional env vars for the Marquez container        | `[]`                                   |
+| `marquez.extraEnvFrom`        | Additional envFrom sources for the Marquez container | `[]`                                   |
 | `marquez.extraContainers`     | Sidecar containers to add to the Marquez pod         | `[]`                                   |
 | `marquez.pdb.create`          | Create PodDisruptionBudget                           | `false`                                |
 | `marquez.podSecurityContext`  | Pod security context                                 | `{}`                                   |
@@ -104,6 +111,33 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.create` | Create ServiceAccount                 | `true`  |
 | `serviceAccount.name`   | ServiceAccount name to use            | `""`    |
 | `ingress.enabled`       | Enable Ingress                        | `false` |
+
+## Database credentials from an existing secret
+
+When `marquez.existingSecretName` is set, the database password is read from that
+secret (key `marquez-db-password` by default). The remaining connection settings
+can also be read from the same secret by naming their keys in
+`marquez.existingSecretKeys`; any key left empty falls back to the plain values
+under `marquez.db`.
+
+This makes the chart work with secrets managed by external operators. For
+example, [movetokube/postgres-operator](https://github.com/movetokube/postgres-operator)
+generates the role name and password and stores the connection details in a
+secret with the keys `HOSTNAME`, `PORT`, `DATABASE_NAME`, `ROLE`, and `PASSWORD`:
+
+```yaml
+marquez:
+  existingSecretName: postgres-marquez  # secret created by the operator
+  existingSecretKeys:
+    hostKey: HOSTNAME
+    portKey: PORT
+    databaseKey: DATABASE_NAME
+    userKey: ROLE
+    passwordKey: PASSWORD
+```
+
+No values under `marquez.db` are used in that setup, and credential rotation by
+the operator is picked up on the next pod restart.
 
 ## Local Installation Guide
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -101,3 +101,75 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Database environment variables (POSTGRES_HOST/PORT/DB/USER) for the Marquez
+containers. Each value is read from the existing secret when the matching key
+in marquez.existingSecretKeys is set; otherwise it falls back to the bundled
+PostgreSQL subchart or the plain values under marquez.db.
+*/}}
+{{- define "ilum-marquez.databaseEnv" -}}
+{{- $keys := default dict .Values.marquez.existingSecretKeys -}}
+- name: POSTGRES_HOST
+{{- if and .Values.marquez.existingSecretName $keys.hostKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.marquez.existingSecretName }}
+      key: {{ $keys.hostKey }}
+{{- else if .Values.postgresql.enabled }}
+  value: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" | quote }}
+{{- else }}
+  value: {{ .Values.marquez.db.host | quote }}
+{{- end }}
+- name: POSTGRES_PORT
+{{- if and .Values.marquez.existingSecretName $keys.portKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.marquez.existingSecretName }}
+      key: {{ $keys.portKey }}
+{{- else if .Values.postgresql.enabled }}
+  value: "5432"
+{{- else }}
+  value: {{ .Values.marquez.db.port | quote }}
+{{- end }}
+- name: POSTGRES_DB
+{{- if and .Values.marquez.existingSecretName $keys.databaseKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.marquez.existingSecretName }}
+      key: {{ $keys.databaseKey }}
+{{- else if .Values.postgresql.enabled }}
+  value: {{ .Values.postgresql.auth.database | quote }}
+{{- else }}
+  value: {{ .Values.marquez.db.name | quote }}
+{{- end }}
+- name: POSTGRES_USER
+{{- if and .Values.marquez.existingSecretName $keys.userKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.marquez.existingSecretName }}
+      key: {{ $keys.userKey }}
+{{- else if .Values.postgresql.enabled }}
+  value: {{ .Values.postgresql.auth.username | quote }}
+{{- else }}
+  value: {{ .Values.marquez.db.user | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+secretKeyRef pointing at the database password.
+*/}}
+{{- define "ilum-marquez.databasePasswordSecretKeyRef" -}}
+{{- $keys := default dict .Values.marquez.existingSecretKeys -}}
+secretKeyRef:
+{{- if .Values.marquez.existingSecretName }}
+  name: {{ .Values.marquez.existingSecretName }}
+  key: {{ default "marquez-db-password" $keys.passwordKey }}
+{{- else if .Values.postgresql.enabled }}
+  name: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
+  key: password
+{{- else }}
+  name: {{ include "ilum-marquez.fullname" . }}
+  key: marquez-db-password
+{{- end }}
+{{- end }}

--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -74,24 +74,10 @@ spec:
               done
               echo "Database ${POSTGRES_DB} is ready!"
           env:
-            - name: POSTGRES_HOST
-              value: {{ .Values.marquez.db.host | quote }}
-            - name: POSTGRES_PORT
-              value: {{ .Values.marquez.db.port | quote }}
-            - name: POSTGRES_USER
-              value: {{ .Values.marquez.db.user | quote }}
+            {{- include "ilum-marquez.databaseEnv" . | nindent 12 }}
             - name: PGPASSWORD
               valueFrom:
-                secretKeyRef:
-                  {{- if .Values.marquez.existingSecretName }}
-                  name: {{ .Values.marquez.existingSecretName }}
-                  key: marquez-db-password
-                  {{- else }}
-                  name: {{ include "ilum-marquez.fullname" . }}
-                  key: marquez-db-password
-                  {{- end }}
-            - name: POSTGRES_DB
-              value: {{ .Values.marquez.db.name | quote }}
+                {{- include "ilum-marquez.databasePasswordSecretKeyRef" . | nindent 16 }}
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -127,29 +113,28 @@ spec:
               value: {{ 5001 | quote }}
             - name: MARQUEZ_CONFIG
               value: /usr/src/app/config.yml
-            - name: POSTGRES_HOST
-              value: {{ if .Values.postgresql.enabled }}{{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}{{ else }}{{ .Values.marquez.db.host | quote }}{{ end }}
-            - name: POSTGRES_PORT
-              value: {{ if .Values.postgresql.enabled }}{{ "5432" | quote }}{{ else }}{{ .Values.marquez.db.port | quote }}{{ end }}
-            - name: POSTGRES_DB
-              value: {{ if .Values.postgresql.enabled }}{{ .Values.postgresql.auth.database | quote }}{{ else }}{{ .Values.marquez.db.name | quote }}{{ end }}
-            - name: POSTGRES_USER
-              value: {{ if .Values.postgresql.enabled }}{{ .Values.postgresql.auth.username | quote }}{{ else }}{{ .Values.marquez.db.user | quote }}{{ end }}
+            {{- include "ilum-marquez.databaseEnv" . | nindent 12 }}
             - name: POSTGRES_PASSWORD
               valueFrom:
-                secretKeyRef:
-                  {{- if .Values.marquez.existingSecretName }}
-                  name: {{ .Values.marquez.existingSecretName }}
-                  key: marquez-db-password
-                  {{- else if .Values.postgresql.enabled }}
-                  name: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
-                  key: password
-                  {{- else }}
-                  name: {{ include "ilum-marquez.fullname" . }}
-                  key: marquez-db-password
-                  {{- end }}
+                {{- include "ilum-marquez.databasePasswordSecretKeyRef" . | nindent 16 }}
             - name: MIGRATE_ON_STARTUP
               value: {{ .Values.marquez.migrateOnStartup | quote }}
+            {{- if .Values.marquez.dbRetention.enabled }}
+            # Rust backend reads retention from env; Java backend reads dbRetention from the config file.
+            - name: MARQUEZ_DB_RETENTION__FREQUENCY_MINS
+              value: {{ .Values.marquez.dbRetention.frequencyMins | quote }}
+            - name: MARQUEZ_DB_RETENTION__NUMBER_OF_ROWS_PER_BATCH
+              value: {{ .Values.marquez.dbRetention.numberOfRowsPerBatch | quote }}
+            - name: MARQUEZ_DB_RETENTION__RETENTION_DAYS
+              value: {{ .Values.marquez.dbRetention.retentionDays | quote }}
+            {{- end }}
+            {{- with .Values.marquez.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.marquez.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.marquez.resources }}
           resources: {{- toYaml .Values.marquez.resources | nindent 12 }}
           {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,9 +56,31 @@ marquez:
 
   ## Name of the existing secret containing credentials for the Marquez installation.
   ## When this is specified, it will take precedence over the values configured in the 'db' section.
-  ## The secret must contain the key 'marquez-db-password'.
+  ## By default the secret must contain the key 'marquez-db-password'; see existingSecretKeys.
   ##
   existingSecretName: ""
+
+  ## Keys read from the existing secret. Only used when existingSecretName is set.
+  ## 'passwordKey' must exist in the secret. The remaining keys are optional: when
+  ## a key name is set, the corresponding connection setting is read from the
+  ## secret instead of the 'db' section below. This lets operator-managed secrets
+  ## (e.g. movetokube/postgres-operator, which generates role names and passwords)
+  ## drive the whole database configuration:
+  ##
+  ##   existingSecretName: postgres-marquez
+  ##   existingSecretKeys:
+  ##     hostKey: HOSTNAME
+  ##     portKey: PORT
+  ##     databaseKey: DATABASE_NAME
+  ##     userKey: ROLE
+  ##     passwordKey: PASSWORD
+  ##
+  existingSecretKeys:
+    passwordKey: marquez-db-password
+    hostKey: ""
+    portKey: ""
+    databaseKey: ""
+    userKey: ""
 
   ## Pod Disruption Budget configuration
   ##
@@ -86,6 +108,19 @@ marquez:
   ## Extra containers to add to the Marquez pod
   ##
   extraContainers: []
+
+  ## Additional environment variables for the Marquez container
+  ##
+  extraEnv: []
+  ## - name: MARQUEZ_SEARCH__ENABLED
+  ##   value: "true"
+
+  ## Additional envFrom sources (ConfigMaps/Secrets) for the Marquez container.
+  ## Note: variables defined via 'env' take precedence over envFrom in Kubernetes.
+  ##
+  extraEnvFrom: []
+  ## - secretRef:
+  ##     name: my-secret
 
   ## Postgres database settings where Marquez data will persist
   ## Only used if postgresql.enabled is false

--- a/docker/entrypoint-rs.sh
+++ b/docker/entrypoint-rs.sh
@@ -5,36 +5,51 @@
 #
 # Usage: $ ./entrypoint-rs.sh
 # Entrypoint for the Rust Marquez API Docker image.
+#
+# Configuration precedence, highest first:
+#   1. Explicit Figment variables (MARQUEZ_DB__HOST, MARQUEZ_SEARCH__PORT, ...)
+#   2. Conventional variables (POSTGRES_*, MARQUEZ_DB_*, POSTGRESQL_HOST, SEARCH_*, ...)
+#   3. The configuration file (MARQUEZ_CONFIG, defaults to marquez.dev.yml)
 
 set -e
 
-# Map MARQUEZ_DB_* → POSTGRES_* (same logic as Java entrypoint)
-[[ -n "${MARQUEZ_DB_HOST}" ]] && export POSTGRES_HOST="${MARQUEZ_DB_HOST}"
-[[ -n "${POSTGRESQL_HOST}" && -z "${POSTGRES_HOST}" ]] && export POSTGRES_HOST="${POSTGRESQL_HOST}"
-[[ -n "${MARQUEZ_DB_PORT}" ]] && export POSTGRES_PORT="${MARQUEZ_DB_PORT}"
-[[ -n "${MARQUEZ_DB}" ]] && export POSTGRES_DB="${MARQUEZ_DB}"
-[[ -n "${MARQUEZ_DB_USER}" ]] && export POSTGRES_USER="${MARQUEZ_DB_USER}"
-[[ -n "${MARQUEZ_DB_PASSWORD}" ]] && export POSTGRES_PASSWORD="${MARQUEZ_DB_PASSWORD}"
+# Map MARQUEZ_DB_* / POSTGRESQL_HOST aliases onto POSTGRES_* (same logic as the Java entrypoint)
+[[ -n "${MARQUEZ_DB_HOST}" ]] && POSTGRES_HOST="${MARQUEZ_DB_HOST}"
+[[ -n "${POSTGRESQL_HOST}" && -z "${POSTGRES_HOST}" ]] && POSTGRES_HOST="${POSTGRESQL_HOST}"
+[[ -n "${MARQUEZ_DB_PORT}" ]] && POSTGRES_PORT="${MARQUEZ_DB_PORT}"
+[[ -n "${MARQUEZ_DB}" ]] && POSTGRES_DB="${MARQUEZ_DB}"
+[[ -n "${MARQUEZ_DB_USER}" ]] && POSTGRES_USER="${MARQUEZ_DB_USER}"
+[[ -n "${MARQUEZ_DB_PASSWORD}" ]] && POSTGRES_PASSWORD="${MARQUEZ_DB_PASSWORD}"
 
-# Map to Figment env vars (MARQUEZ_ prefix, __ for nesting)
-# Field names use snake_case to match Rust struct fields (Figment splits on __ for nesting)
-export MARQUEZ_DB__HOST="${POSTGRES_HOST:-localhost}"
-export MARQUEZ_DB__PORT="${POSTGRES_PORT:-5432}"
-export MARQUEZ_DB__NAME="${POSTGRES_DB:-marquez}"
-export MARQUEZ_DB__USER="${POSTGRES_USER:-marquez}"
-export MARQUEZ_DB__PASSWORD="${POSTGRES_PASSWORD:-marquez}"
-export MARQUEZ_DB__MAX_POOL_SIZE="${MARQUEZ_DB_POOL_SIZE:-10}"
-export MARQUEZ_SERVER__PORT="${MARQUEZ_PORT:-5000}"
-export MARQUEZ_SERVER__ADMIN_PORT="${MARQUEZ_ADMIN_PORT:-5001}"
-export MARQUEZ_SERVER__HOST="0.0.0.0"
+# Export a Figment variable only when a value was actually provided and the
+# Figment variable itself is not already set. Values coming from a mounted
+# MARQUEZ_CONFIG file are no longer clobbered by hardcoded defaults.
+map_env() {
+  local target="$1" value="$2"
+  if [[ -n "${value}" && -z "${!target}" ]]; then
+    export "${target}=${value}"
+  fi
+}
+
+map_env MARQUEZ_DB__HOST "${POSTGRES_HOST}"
+map_env MARQUEZ_DB__PORT "${POSTGRES_PORT}"
+map_env MARQUEZ_DB__NAME "${POSTGRES_DB}"
+map_env MARQUEZ_DB__USER "${POSTGRES_USER}"
+map_env MARQUEZ_DB__PASSWORD "${POSTGRES_PASSWORD}"
+map_env MARQUEZ_DB__MAX_POOL_SIZE "${MARQUEZ_DB_POOL_SIZE}"
+
+map_env MARQUEZ_SERVER__PORT "${MARQUEZ_PORT}"
+map_env MARQUEZ_SERVER__ADMIN_PORT "${MARQUEZ_ADMIN_PORT}"
+
+map_env MARQUEZ_MIGRATE_ON_STARTUP "${MIGRATE_ON_STARTUP}"
 
 # Search (OpenSearch) configuration
-export MARQUEZ_SEARCH__ENABLED="${SEARCH_ENABLED:-false}"
-export MARQUEZ_SEARCH__HOST="${SEARCH_HOST:-opensearch}"
-export MARQUEZ_SEARCH__PORT="${SEARCH_PORT:-9200}"
-export MARQUEZ_SEARCH__USERNAME="${SEARCH_USERNAME:-admin}"
-export MARQUEZ_SEARCH__PASSWORD="${SEARCH_PASSWORD:-CHANGEMEPLEASE1@#a}"
-export MARQUEZ_SEARCH__SCHEME="${SEARCH_SCHEME:-http}"
+map_env MARQUEZ_SEARCH__ENABLED "${SEARCH_ENABLED}"
+map_env MARQUEZ_SEARCH__HOST "${SEARCH_HOST}"
+map_env MARQUEZ_SEARCH__PORT "${SEARCH_PORT}"
+map_env MARQUEZ_SEARCH__USERNAME "${SEARCH_USERNAME}"
+map_env MARQUEZ_SEARCH__PASSWORD "${SEARCH_PASSWORD}"
+map_env MARQUEZ_SEARCH__SCHEME "${SEARCH_SCHEME}"
 
 MARQUEZ_CONFIG="${MARQUEZ_CONFIG:-marquez.dev.yml}"
 exec ./marquez-api serve --config "${MARQUEZ_CONFIG}"


### PR DESCRIPTION
### What change does this PR introduce?

**Chart (0.54.1):**
- New `marquez.existingSecretKeys` (`passwordKey`, `hostKey`, `portKey`, `databaseKey`, `userKey`). Any key that is set is read from `existingSecretName`; keys left empty fall back to the plain `marquez.db` values. Fully backward compatible: the default is still password-only via `marquez-db-password`.
- The main container and the `wait-for-db` init container now share the DB env wiring through helpers, so they can never disagree.
- New `marquez.extraEnv` and `marquez.extraEnvFrom` passthroughs.
- `MARQUEZ_DB_RETENTION__*` env is passed when `dbRetention.enabled`; the Rust backend reads retention from the environment and ignored the Dropwizard-style config block, so the chart setting silently did nothing on the default image.

**Docker (Rust entrypoint):**
- `entrypoint-rs.sh` exported every `MARQUEZ_DB__*`, `MARQUEZ_SEARCH__*`, and server variable unconditionally with hardcoded fallbacks. Figment merges env after the config file, so a mounted `MARQUEZ_CONFIG` had its db, search, and server sections silently replaced by defaults, and even explicitly set `MARQUEZ_DB__*` variables were clobbered.
- Variables are now mapped only when a value was actually provided. Precedence, highest first: explicit Figment variables, then the conventional `POSTGRES_*` / `MARQUEZ_DB_*` / `POSTGRESQL_HOST` / `SEARCH_*` variables, then the config file. Alias precedence stays identical to the Java entrypoint. `MIGRATE_ON_STARTUP` is now mapped as well (the chart sets it, but the Rust image ignored it).

**API (Rust config):**
- `DbConfig` fields, and the `db` section itself, now carry serde defaults matching the bundled `marquez.dev.yml` (`localhost:5432`, database/user/password `marquez`), mirroring the existing `ServerConfig` pattern. A `MARQUEZ_CONFIG` file with a partial or missing `db` section starts with the standard defaults instead of aborting, so the always-starts behavior of the old entrypoint is preserved under the corrected precedence.

### Why was this change needed?

A user in the upstream environment-variables thread (MarquezProject `#2795`) wants to configure the Marquez database through movetokube/postgres-operator. That operator generates the role name and password and stores all connection details in a Kubernetes secret, so none of them can live in `values.yaml`; our chart could only take the password from a secret. Separately, the Rust entrypoint broke the documented "environment overrides the config file" contract for anyone mounting their own config.

### How does this solve the problem?

The operator's default secret keys map directly, no secret templating required:

```yaml
marquez:
  existingSecretName: postgres-marquez  # secret created by the operator
  existingSecretKeys:
    hostKey: HOSTNAME
    portKey: PORT
    databaseKey: DATABASE_NAME
    userKey: ROLE
    passwordKey: PASSWORD
```

Credential rotation by the operator is picked up on the next pod restart. For non-Helm deployments, `extraEnvFrom`-style setups and plain `POSTGRES_*` / `MARQUEZ_DB_*` env vars keep working through the entrypoint mapping.

### Validation

- `helm lint` passes; rendered manifests for the default, `existingSecretName`-only, and `postgresql.enabled` scenarios are identical to a pre-change baseline (apart from the chart version label and one env reordering).
- The movetokube-style scenario renders all five settings from the secret in both the init and main containers; nulled or partial `existingSecretKeys` fall back correctly, so old values files keep working.
- Image built and the full stack booted with `./docker/up.sh --build --detach --no-web --no-search`: API healthy, migrations applied, `/api/v1/namespaces` served.
- Bare `docker run` with zero environment starts and connects to `localhost:5432/marquez`, byte-identical to the previous force-exported defaults (verified by sharing the db container's network namespace).
- A container started with only a mounted `MARQUEZ_CONFIG` (custom ports, db host) honors the file: it listened on the file's ports and connected to the file's host. Before this fix the same container was forced onto 5000/5001 and `localhost`.
- A config file containing only a `server` section (no `db` at all) with zero environment also boots on the file's port with default `localhost` credentials, so no configuration shape fails on first start.
- The ilum umbrella chart (`ilum/ilum`) overrides only `marquez.db.password` and disables web/postgresql; everything else flows through this chart's defaults, which are unchanged.
- `cargo check` and `cargo clippy` clean on `marquez-api`.
- No overlap with the Windows script fixes from #19: only `entrypoint-rs.sh` changed on the docker side, it runs exclusively inside the Linux container, and `.gitattributes` (`*.sh text eol=lf`) covers it. `up.sh`, `volumes.sh`, and `down.sh` were exercised during validation.

### CI note

While verifying this PR it turned out `rust-ci.yml` still triggered only for the merged `rust` integration branch, so no Rust CI has run on any PR since the rewrite landed on `main` (and GitHub Actions is currently disabled for this fork, so no workflow has ever executed; it can be enabled under Settings > Actions). This PR therefore also:

- points the Rust CI triggers at `main`
- applies current stable rustfmt to three test files whose drift would fail the `cargo fmt --all -- --check` gate on the first real run

As a substitute for CI, the full workspace suite was executed locally under the exact CI environment (postgres:16 service, `TEST_POSTGRES_*` vars): 618 tests passed, 0 failed, across all 11 test targets.
