### PR TITLE
fix: runs with a ParentRunFacet on their first event were counted but never listed

### DIFF
--- a/api-rs/marquez-api/src/db/openlineage.rs
+++ b/api-rs/marquez-api/src/db/openlineage.rs
@@ -815,7 +815,10 @@ pub async fn update_base_marquez_model(
         ended_at,
         None,
         &ns_name,
-        job_name,
+        // Canonical name from the jobs_view trigger (parent-qualified for jobs
+        // created with a parent facet), not the raw event name: runs.job_name
+        // must match jobs.name or list and count queries disagree.
+        &job_row.name,
         location,
         None,
     )

--- a/api-rs/marquez-api/src/db/run.rs
+++ b/api-rs/marquez-api/src/db/run.rs
@@ -358,10 +358,13 @@ pub async fn find_by_latest_job(
     offset: i32,
 ) -> Result<Vec<ExtendedRunWithFacetsRow>, sqlx::Error> {
     sqlx::query_as::<_, ExtendedRunWithFacetsRow>(
-        "WITH target_runs AS ( \
+        "WITH filtered_jobs AS ( \
+            SELECT jv.uuid FROM jobs_view jv \
+            WHERE jv.namespace_name = $1 AND (jv.name = $2 OR $2 = ANY(jv.aliases)) \
+        ), \
+        target_runs AS ( \
             SELECT r.uuid FROM runs_view r \
-            INNER JOIN jobs_view j ON j.namespace_name = r.namespace_name AND j.name = r.job_name \
-            WHERE j.namespace_name = $1 AND (j.name = $2 OR $2 = ANY(j.aliases)) \
+            INNER JOIN filtered_jobs fj ON r.job_uuid = fj.uuid \
             ORDER BY r.transitioned_at DESC NULLS LAST, r.started_at DESC NULLS LAST, r.uuid ASC \
             LIMIT $3 OFFSET $4 \
         ) \

--- a/api-rs/tests/src/api_tests/openlineage_test.rs
+++ b/api-rs/tests/src/api_tests/openlineage_test.rs
@@ -2520,3 +2520,117 @@ async fn dataset_fields_reflect_current_version() {
     );
     assert_eq!(list_fields[0]["name"], "id");
 }
+
+/// Helper: GET the runs page (totalCount + runs) for a job.
+async fn get_job_runs(app: &TestApp, ns: &str, job: &str) -> Value {
+    let url = format!(
+        "{}/api/v1/namespaces/{}/jobs/{}/runs?limit=10",
+        app.base_url,
+        encode(ns),
+        encode(job)
+    );
+    let resp = app.client.get(&url).send().await.expect("get job runs");
+    assert_eq!(resp.status(), 200, "get job runs failed: {}", resp.status());
+    resp.json().await.expect("parse runs json")
+}
+
+/// A run whose very first event already carries a ParentRunFacet whose parent
+/// name is not a prefix of the job name (the Spark application pattern with a
+/// static parent-run config). The job is stored under its parent-qualified
+/// canonical name; the runs list and totalCount must agree under that name
+/// instead of counting a run that is never listed (issue #21).
+#[tokio::test]
+async fn parent_facet_on_first_event_runs_list_consistent() {
+    let app = TestApp::new().await;
+    let ns = generators::new_namespace_name();
+    let parent_name = format!("dag_{}", rand::random_range(0..u32::MAX));
+    let child_name = format!("spark_app_{}", rand::random_range(0..u32::MAX));
+    let run_id = Uuid::new_v4().to_string();
+    let parent_run_id = Uuid::new_v4().to_string();
+
+    let parent_facet = json!({
+        "parent": {
+            "_producer": "test",
+            "_schemaURL": "test",
+            "run": { "runId": parent_run_id },
+            "job": { "namespace": ns, "name": parent_name }
+        }
+    });
+    let event = make_run_event(
+        "COMPLETE",
+        &ns,
+        &child_name,
+        &run_id,
+        vec![],
+        vec![],
+        Some(parent_facet),
+        None,
+    );
+    post_lineage(&app, &event).await;
+
+    // Listed and counted under the canonical parent-qualified name.
+    let canonical = format!("{parent_name}.{child_name}");
+    let page = get_job_runs(&app, &ns, &canonical).await;
+    assert_eq!(page["totalCount"].as_i64(), Some(1));
+    let runs = page["runs"].as_array().expect("runs array");
+    assert_eq!(runs.len(), 1, "count and list must agree: {page}");
+    assert_eq!(runs[0]["id"].as_str(), Some(run_id.as_str()));
+
+    // The raw event name is not a job identity; count and list agree on empty.
+    let plain = get_job_runs(&app, &ns, &child_name).await;
+    assert_eq!(plain["totalCount"].as_i64(), Some(0));
+    assert_eq!(plain["runs"].as_array().expect("runs array").len(), 0);
+}
+
+/// A bare START first, with the parent facet only arriving on COMPLETE: the
+/// run stays attached to the plain-named job created by the first event and
+/// remains consistently counted and listed under that name (issue #21).
+#[tokio::test]
+async fn parent_facet_on_later_event_runs_list_consistent() {
+    let app = TestApp::new().await;
+    let ns = generators::new_namespace_name();
+    let parent_name = format!("dag_{}", rand::random_range(0..u32::MAX));
+    let child_name = format!("spark_app_{}", rand::random_range(0..u32::MAX));
+    let run_id = Uuid::new_v4().to_string();
+    let parent_run_id = Uuid::new_v4().to_string();
+
+    let start = make_run_event(
+        "START",
+        &ns,
+        &child_name,
+        &run_id,
+        vec![],
+        vec![],
+        None,
+        None,
+    );
+    post_lineage(&app, &start).await;
+
+    let parent_facet = json!({
+        "parent": {
+            "_producer": "test",
+            "_schemaURL": "test",
+            "run": { "runId": parent_run_id },
+            "job": { "namespace": ns, "name": parent_name }
+        }
+    });
+    let complete = make_run_event(
+        "COMPLETE",
+        &ns,
+        &child_name,
+        &run_id,
+        vec![],
+        vec![],
+        Some(parent_facet),
+        None,
+    );
+    post_lineage(&app, &complete).await;
+
+    let page = get_job_runs(&app, &ns, &child_name).await;
+    assert_eq!(page["totalCount"].as_i64(), Some(1));
+    assert_eq!(
+        page["runs"].as_array().expect("runs array").len(),
+        1,
+        "count and list must agree: {page}"
+    );
+}

--- a/api-rs/tests/src/db_tests/migration_test.rs
+++ b/api-rs/tests/src/db_tests/migration_test.rs
@@ -159,3 +159,97 @@ async fn test_repeatable_migrations_idempotent() {
         .await
         .expect("second migration run should succeed (repeatable migrations are idempotent)");
 }
+
+/// V77 repairs runs whose denormalized job_name kept the raw event name while
+/// the job was stored under its parent-qualified canonical name (issue #21).
+#[tokio::test]
+async fn test_v77_backfills_run_job_name_for_parented_jobs() {
+    use chrono::Utc;
+    use marquez_api::db::{job, namespace, run};
+    use uuid::Uuid;
+
+    let (pool, _container) = setup_test_db().await;
+    let runner = MigrationRunner::new(migrations_dir());
+    runner.run_all(&pool).await.expect("migrations apply");
+
+    let now = Utc::now();
+    let ns = namespace::upsert(&pool, Uuid::new_v4(), now, "v77_ns", "anonymous", None)
+        .await
+        .expect("namespace");
+
+    let parent = job::upsert(
+        &pool,
+        Uuid::new_v4(),
+        "BATCH",
+        now,
+        ns.uuid,
+        &ns.name,
+        "v77_parent",
+        None,
+        None,
+        None,
+        Some("v77_parent"),
+        None,
+        None,
+    )
+    .await
+    .expect("parent job");
+
+    // The jobs_view trigger stores this job under 'v77_parent.v77_child'.
+    let child = job::upsert(
+        &pool,
+        Uuid::new_v4(),
+        "BATCH",
+        now,
+        ns.uuid,
+        &ns.name,
+        "v77_child",
+        None,
+        None,
+        None,
+        Some("v77_child"),
+        Some(parent.uuid),
+        None,
+    )
+    .await
+    .expect("child job");
+    assert_eq!(child.name, "v77_parent.v77_child");
+
+    // Recreate the pre-V77 divergence: the run kept the raw event name.
+    let run_uuid = Uuid::new_v4();
+    run::upsert(
+        &pool,
+        run_uuid,
+        now,
+        Some(child.uuid),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some("COMPLETED"),
+        None,
+        None,
+        None,
+        None,
+        &ns.name,
+        "v77_child",
+        None,
+        None,
+    )
+    .await
+    .expect("run");
+
+    let sql = std::fs::read_to_string(
+        migrations_dir().join("V77__fix_runs_job_name_for_parented_jobs.sql"),
+    )
+    .expect("read V77 migration");
+    sqlx::raw_sql(&sql).execute(&pool).await.expect("apply V77");
+
+    let (job_name,): (String,) = sqlx::query_as("SELECT job_name FROM runs WHERE uuid = $1")
+        .bind(run_uuid)
+        .fetch_one(&pool)
+        .await
+        .expect("read run");
+    assert_eq!(job_name, "v77_parent.v77_child");
+}

--- a/api/src/main/resources/marquez/db/migration/V77__fix_runs_job_name_for_parented_jobs.sql
+++ b/api/src/main/resources/marquez/db/migration/V77__fix_runs_job_name_for_parented_jobs.sql
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Repair runs whose denormalized job_name kept the raw OpenLineage event name
+   instead of the job's canonical name. When the first event of a run already
+   carried a ParentRunFacet, the job was stored under its parent-qualified name
+   ('parent.child') while the run kept 'child'. Queries that resolve the job by
+   its canonical name (runs listing) and queries that match runs.job_name
+   directly (run counts) then disagreed: the run was counted but never listed.
+   Align runs.job_name with the same COALESCE(symlink.name, job.name) that
+   runs_view exposes. */
+UPDATE runs r
+SET job_name = COALESCE(s.name, j.name)
+FROM jobs j
+LEFT JOIN jobs s ON s.uuid = j.symlink_target_uuid
+WHERE r.job_uuid = j.uuid
+  AND r.job_name IS DISTINCT FROM COALESCE(s.name, j.name);

--- a/web/src/routes/dashboard/JobRunItem.tsx
+++ b/web/src/routes/dashboard/JobRunItem.tsx
@@ -22,7 +22,10 @@ const JobRunItem: React.FC<Props> = ({ job }) => {
   const navigate = useNavigate()
   const reversedRuns = [...(job.latestRuns || [])].reverse()
   const longestRun = useMemo(
-    () => job.latestRuns?.reduce((acc, run) => (acc.durationMs > run.durationMs ? acc : run)),
+    () =>
+      job.latestRuns?.length
+        ? job.latestRuns.reduce((acc, run) => (acc.durationMs > run.durationMs ? acc : run))
+        : undefined,
     [job.latestRuns]
   )
   return (
@@ -99,7 +102,7 @@ const JobRunItem: React.FC<Props> = ({ job }) => {
                     mr={0.5}
                     minHeight={2}
                     width={5}
-                    height={(run.durationMs / longestRun.durationMs) * 40}
+                    height={(run.durationMs / (longestRun?.durationMs || 1)) * 40}
                     sx={{
                       borderTopLeftRadius: theme.shape.borderRadius,
                       borderTopRightRadius: theme.shape.borderRadius,


### PR DESCRIPTION
Closes #21

### What change does this PR introduce?

A run whose very first OpenLineage event already carried a `ParentRunFacet` (the Spark-application pattern with static parent-run config) became permanently invisible to the runs list while still being counted: `{"totalCount": 1, "runs": []}`. One such job in a namespace was enough to crash the web UI's job list. Reproduced exactly as described in #21 via minimal synthetic events before fixing.

**Root cause.** The shared `jobs_view` trigger stores a job created with `parent_job_uuid` under its parent-qualified canonical name (`parent.child`), but our ingestion bound the raw event name into the denormalized `runs.job_name` column. The two runs endpoints then disagreed: `totalCount` matches `runs.job_name` directly, while the list resolves the job through `jobs_view` by canonical name or aliases. The mismatch cut both ways: the plain name gave `totalCount: 1, runs: []` and the canonical name gave `totalCount: 0, runs: [1]`. Runs whose first event had no parent facet were unaffected, which is why the Airflow-style flow (facet-light `START` first) always worked and why existing tests missed it: they used task names already prefixed with the DAG name, making raw and canonical names identical.

**Fixes:**
1. `db/openlineage.rs`: bind the canonical job name returned by the `jobs_view` trigger into the run row, restoring the invariant `runs.job_name == jobs.name` that the Java backend maintains (`RunDao.upsert` receives `jobRow.getName()`).
2. `db/run.rs` (`find_by_latest_job`): adopt Java's `RunDao.findAll` shape, resolving jobs first (`filtered_jobs` CTE on name or aliases) and joining runs by `job_uuid` instead of by the denormalized name string.
3. `V77__fix_runs_job_name_for_parented_jobs.sql`: backfill migration repairing existing rows, aligning `runs.job_name` with the same `COALESCE(symlink.name, job.name)` that `runs_view` exposes.
4. `web` (`JobRunItem.tsx`): guard the `latestRuns.reduce()` call that threw `Reduce of empty array with no initial value` and unmounted the whole dashboard. This is required, not just defensive: when the parent facet arrives only after a bare `START`, the run stays on the plain-named job and the parent-qualified job row legitimately exists with zero runs, so the jobs list can still contain `latestRuns: []` entries even with the fixed backend.

### Validation

- New API regression tests replaying the reporter's scenarios: first-event parent facet with an unprefixed job name (count and list agree under the canonical name, and agree on empty under the raw name), and parent facet arriving after a bare `START` (stays consistently listed under the plain name).
- New migration test: creates the exact pre-V77 divergence through the real DAOs (jobs_view trigger included) and asserts V77 repairs it.
- Full workspace suite: 621 passed, 0 failed, under the CI environment (postgres:16, `TEST_POSTGRES_*`).
- Live end-to-end (backend): reproduced the bug on a stack built from `main` (`totalCount: 1, runs: []` and the inverted `totalCount: 0, runs: [1]` under the FQN), then verified the fixed image lists and counts consistently for fresh ingestion, and that V77 repaired the pre-existing divergent rows in the same database.
- Live end-to-end (web, browser-level A/B): against the published `ilum/marquez:0.54.0` API image with a job in the `latestRuns: []` shape, headless Chrome on the unguarded web build renders an empty React root and logs the exact `Uncaught TypeError: Reduce of empty array with no initial value` from the report; the guarded build renders the full dashboard including the poisoned job, with a clean console. The A/B also caught a `TS18048` strict-null error at the `longestRun` usage site that the initial guard missed; fixed and rebuilt.
- SQL parity catalog: GAP count unchanged at 0; the touched queries keep their prior SEMANTIC_DIFF classification (structural pagination differences, same semantics).
